### PR TITLE
Rename opt-in header to cant-be-evil

### DIFF
--- a/src/background_page/constants.js
+++ b/src/background_page/constants.js
@@ -22,7 +22,7 @@ export const AUTH_PATH = '/auth'
 export const AUTH_SEARCH = '?authRequest='
 export const CONFIG_STORAGE_KEY = 'config'
 export const APP_DATA_STORAGE_KEY = 'apps'
-export const OPT_IN_HEADER_NAME = "can't-be-evil"
+export const OPT_IN_HEADER_NAME = "cant-be-evil"
 export const CSP_REPORT_KEY = 'cantbeevil-csp-report'
 
 export const ICONS_GRAY = {

--- a/src/background_page/utils.js
+++ b/src/background_page/utils.js
@@ -51,7 +51,7 @@ export function getHeaderValue (headerName, headers) {
 }
 
 /**
- * Returns true if the `can't-be-evil` header exists and is set to `true`,
+ * Returns true if the `cant-be-evil` header exists and is set to `true`,
  * otherwise false
  * @param {Array} headers
  */


### PR DESCRIPTION
This PR
* renames the opt-in header from `can't-be-evil` to `cant-be-evil`
* fixes #16 