### PR TITLE
Remove CSP sandbox directive

### DIFF
--- a/src/background_page/csp.js
+++ b/src/background_page/csp.js
@@ -30,7 +30,6 @@ export function injectCspProcessor (details) {
   const enforce = enabled(headers)
   tabDataArray[tabId] = { enforce, compliant: true }
 
-  const sandboxCsp = 'sandbox allow-scripts allow-same-origin;'
   const scriptCsp =
     "script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval';"
   const styleCsp =
@@ -51,7 +50,7 @@ export function injectCspProcessor (details) {
 
   const reportingEnabled = Config.isReportingEnabled()
   const includeReportDirective = enforce || reportingEnabled
-  const cspValue = `default-src 'none'; ${sandboxCsp} ${scriptCsp} ${styleCsp} ${imageCsp} ${fontCsp} ${mediaCsp} ${objectCsp} ${prefetchCsp} ${frameCsp} ${workerCsp} ${formActionCsp} ${manifestCsp} ${disownOpener} ${connectCsp} ${includeReportDirective
+  const cspValue = `default-src 'none'; ${scriptCsp} ${styleCsp} ${imageCsp} ${fontCsp} ${mediaCsp} ${objectCsp} ${prefetchCsp} ${frameCsp} ${workerCsp} ${formActionCsp} ${manifestCsp} ${disownOpener} ${connectCsp} ${includeReportDirective
     ? reportUri
     : ''}`
 


### PR DESCRIPTION
The content security policy `sandbox` directive was preventing the use of popups and breaking Blockstack Connect (see #25). The Can't Be Evil Sandbox v1 is limited in scope to cookies and network related security, so we're removing this directive.